### PR TITLE
Add docs for iam_group and correct typo in iam-access-key sidebar.

### DIFF
--- a/website/source/docs/providers/aws/r/iam_access_key.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_access_key.html.markdown
@@ -54,6 +54,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The access key ID.
+* `user` - The IAM user associated with this access key.
 * `secret` - The secret access key. Note that this will be written to the state file.
 * `status` - "Active" or "Inactive". Keys are initially active, but can be made
 	inactive by other means.

--- a/website/source/docs/providers/aws/r/iam_group.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_group.html.markdown
@@ -30,7 +30,10 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `unique_id` - The [unique ID][1] assigned by AWS.
+* `id` - The group's ID.
 * `arn` - The ARN assigned by AWS for this group.
+* `name` - The group's name.
+* `path` - The path of the group in IAM.
+* `unique_id` - The [unique ID][1] assigned by AWS.
 
   [1]: http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html#GUIDs

--- a/website/source/docs/providers/aws/r/iam_group.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_group.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iam_group"
+sidebar_current: "docs-aws-resource-iam-group"
+description: |-
+  Provides an IAM group.
+---
+
+# aws\_iam\_group
+
+Provides an IAM group.
+
+## Example Usage
+
+```
+resource "aws_iam_group" "developers" {
+    name = "developers"
+    path = "/users/"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The group's name.
+* `path` - (Optional, default "/") Path in which to create the group.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `unique_id` - The [unique ID][1] assigned by AWS.
+* `arn` - The ARN assigned by AWS for this group.
+
+  [1]: http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html#GUIDs

--- a/website/source/docs/providers/aws/r/iam_group_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_group_policy.html.markdown
@@ -45,8 +45,11 @@ The following arguments are supported:
 * `policy` - (Required) The policy document. This is a JSON formatted string.
   The heredoc syntax or `file` funciton is helpful here.
 * `name` - (Required) Name of the policy.
-* `user` - (Required) IAM group to which to attach this policy.
+* `user` - (Required) The IAM group to attach to the policy.
 
 ## Attributes Reference
 
-This resource has no attributes.
+* `id` - The group policy ID.
+* `group` - The group to which this policy applies.
+* `name` - The name of the policy.
+* `policy` - The policy document attached to the group.

--- a/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
@@ -48,4 +48,12 @@ The following arguments are supported:
 
 ## Attribute Reference
 
-This resource has no attributes.
+* `id` - The instance profile's ID.
+* `arn` - The ARN assigned by AWS to the instance profile.
+* `create_date` - The creation timestamp of the instance profile.
+* `name` - The instance profile's name.
+* `path` - The path of the instance profile in IAM.
+* `roles` - The list of roles assigned to the instance profile.
+* `unique_id` - The [unique ID][1] assigned by AWS.
+
+  [1]: http://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html#GUIDs

--- a/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iam_instance_profile"
+sidebar_current: "docs-aws-resource-iam-instance-profile"
+description: |-
+  Provides an IAM instance profile.
+---
+
+# aws\_iam\_instance\_profile
+
+Provides an IAM instance profile.
+
+## Example Usage
+
+```
+resource "aws_iam_role" "role" {
+    name = "test_role"
+    path = "/"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_instance_profile" "test_profile" {
+    name = "test_profile"
+    roles = ["${aws_iam_role.role.name}"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The profile's name.
+* `path` - (Optional, default "/") Path in which to create the profile.
+* `roles` - (Required) A list of role names to include in the profile.
+
+## Attribute Reference
+
+This resource has no attributes.

--- a/website/source/docs/providers/aws/r/iam_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_policy.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iam_policy"
+sidebar_current: "docs-aws-resource-iam-policy"
+description: |-
+  Provides an IAM policy.
+---
+
+# aws\_iam\_policy
+
+Provides an IAM policy.
+
+```
+resource "aws_iam_policy" "policy" {
+    name = "test_policy"
+    path = "/"
+    description = "My test policy"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) Description of the IAM policy.
+* `path` - (Optional, default "/") Path in which to create the policy.
+* `policy` - (Required) The policy document. This is a JSON formatted string.
+  The heredoc syntax or `file` funciton is helpful here.
+* `name` (Required) - The name of the policy.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The policy's ID.
+* `arn` - The ARN assigned by AWS to this policy.
+* `description` - The description of the policy.
+* `name` - The name of the policy.
+* `path` - The path of the policy in IAM.
+* `policy` - The policy document.

--- a/website/source/docs/providers/aws/r/iam_role_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_role_policy.html.markdown
@@ -1,0 +1,67 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iam_role_policy"
+sidebar_current: "docs-aws-resource-iam-role-policy"
+description: |-
+  Provides an IAM role policy.
+---
+
+# aws\_iam\_role\_policy
+
+Provides an IAM role policy.
+
+## Example Usage
+
+```
+resource "aws_iam_role" "test_role" {
+    name = "test_role"
+    assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test_policy" {
+    name = "test_policy"
+    role = "${aws_iam_role.test_role.id}"
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the role policy.
+* `policy` - (Required) The policy document. This is a JSON formatted string.
+  The heredoc syntax or `file` funciton is helpful here.
+* `role` - (Required) The IAM role to attach to the policy.
+
+## Attributes Reference
+
+* `id` - The role policy ID.
+* `name` - The name of the policy.
+* `policy` - The policy document attached to the role.
+* `role` - The role to which this policy applies.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -57,6 +57,14 @@
                             <a href="/docs/providers/aws/r/iam_instance_profile.html">aws_iam_instance_profile</a>
                     </li>
 
+                    <li<%= sidebar_current("docs-aws-resource-iam-policy") %>>
+                            <a href="/docs/providers/aws/r/iam_policy.html">aws_iam_policy</a>
+                    </li>
+
+                    <li<%= sidebar_current("docs-aws-resource-iam-role-policy") %>>
+                            <a href="/docs/providers/aws/r/iam_role_policy.html">aws_iam_role_policy</a>
+                    </li>
+
                     <li<%= sidebar_current("docs-aws-resource-iam-user") %>>
                             <a href="/docs/providers/aws/r/iam_user.html">aws_iam_user</a>
                     </li>

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -41,12 +41,20 @@
 					<a href="/docs/providers/aws/r/elb.html">aws_elb</a>
                     </li>
 
-                    <li<%= sidebar_current("docs-aws-resource-iam=access-key") %>>
+                    <li<%= sidebar_current("docs-aws-resource-iam-access-key") %>>
                             <a href="/docs/providers/aws/r/iam_access_key.html">aws_iam_access_key</a>
                     </li>
 
+                    <li<%= sidebar_current("docs-aws-resource-iam-group") %>>
+                            <a href="/docs/providers/aws/r/iam_group.html">aws_iam_group</a>
+                    </li>
+
                     <li<%= sidebar_current("docs-aws-resource-iam-group-policy") %>>
-                            <a href="/docs/providers/aws/r/iam_group_policy.html">aws_iam_user_policy</a>
+                            <a href="/docs/providers/aws/r/iam_group_policy.html">aws_iam_group_policy</a>
+                    </li>
+
+                    <li<%= sidebar_current("docs-aws-resource-iam-instance-profile") %>>
+                            <a href="/docs/providers/aws/r/iam_instance_profile.html">aws_iam_instance_profile</a>
                     </li>
 
                     <li<%= sidebar_current("docs-aws-resource-iam-user") %>>


### PR DESCRIPTION
Adding some sidebar logic left out of my original patch, the iam_group docs, and correcting a minor type in the iam-access-key sidebar.
